### PR TITLE
feat: allow specifying data files to be copied to VM

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,12 @@ inputs:
     description: 'List of test scripts to execute on the VM via SSH after it boots. Exit code determines test status.'
     required: true
   token:
-    description: |
-      The token used to sign into the container registry.
+    description: 'The token used to sign into the container registry.'
     required: true
+  data-files:
+    description: 'List of data files to be copied to the VM via SSH after it boots.'
+    default: ''
+    required: false
   vm-name:
     description: 'Name for the virtual machine and its disk in libvirt.'
     default: 'vm-bootc'
@@ -188,6 +191,7 @@ runs:
       shell: bash
       env:
         TESTS: ${{ inputs.tests }}
+        DATA_FILES: ${{ inputs.data-files }}
       run: |
         echo "Running tests..."
 
@@ -204,6 +208,11 @@ runs:
         mkdir test-logs
         FAILED_TESTS=0
         SSH_OPTS="-o ConnectTimeout=20 -o StrictHostKeyChecking=no -i ~/.ssh/id_ed25519"
+
+        if [ -n "$DATA_FILES" ]; then
+          mapfile -t DATA_FILE_LIST <<< "$DATA_FILES"
+          scp $SSH_OPTS "${DATA_FILE_LIST[@]}" core@"$VM_IP":/home/core/
+        fi
 
         for TEST_FILE in "${TEST_LIST[@]}"; do
           if [ -z "$TEST_FILE" ]; then

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ name: integration-tests
 permissions: {}
 on:
   schedule:
-    - cron: "00 7 * * *" # run at 7:00 UTC every day 
+    - cron: "00 7 * * *" # run at 7:00 UTC every day
 jobs:
   integration-tests:
     name: Run integration tests
@@ -30,15 +30,15 @@ jobs:
       packages: write
       id-token: write
     strategy:
-      fail-fast: false 
+      fail-fast: false
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - name: Run integration tests
-        uses: secureblue/bootc-virtual-machine-action@6638202e094c8f30b06917ccdd3187a1e376cdb9 # v0.0.1
-        with:          
+        uses: secureblue/bootc-integration-test-action@05aa93d5e9d1e128c8d0772fd534fed5c73f9271 # v0.0.3
+        with:
           registry: ghcr.io/secureblue
           image: silverblue-main-hardened
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,6 +57,7 @@ jobs:
 | `image`                | Image name for the VM. Example: silverblue-main-hardened                       | string | Yes      | N/A             |
 | `tests`                | List of test scripts to execute on the VM via SSH after it boots.              | string | Yes      | N/A             |
 | `token`                | Github token                                                                   | string | Yes      | N/A             |
+| `data-files`           | List of data files to be copied to the VM via SSH after it boots.              | string | No       | (empty)         |
 | `vm-name`              | Name for the virtual machine and its disk in libvirt.                          | string | No       | `vm-bootc`      |
 | `vcpus`                | Number of virtual CPUs for the VM.                                             | number | No       | `3`             |
 | `memory-mb`            | Amount of RAM in MB for the VM.                                                | number | No       | `8192`          |


### PR DESCRIPTION
This allows, for example, data to be used by one or more tests to be placed in files that are copied to the VM and available to the tests when they run. The optional input `data-files` can be used to specify such files.